### PR TITLE
Export version information for setuptools_scm in git archives

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+dscribe-name: $Format:%(describe:tags=true,match=*[0-9]*)$e

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst


### PR DESCRIPTION
Currently, downloading mattersim via git archive does not allow to install the package due to missing version information. This patch implements the recommended setup by setuptools-scm to use git archives (see https://setuptools-scm.readthedocs.io/en/latest/usage/#git-archives for more details).