### PR TITLE
Only deploy pages on push and not pull request

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -42,6 +42,7 @@ jobs:
         make html
 
     - name: Deploy to GitHub Pages
+      if: github.event_name == 'push' && github.repository == 'microsoft/mattersim' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/main' )
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It seems like the pages are deployed on pull requests as well, rather than only on main. This adds an additional condition to only deploy on push events.