### PR TITLE
fix: cutoff auto detect in calculate

### DIFF
--- a/src/mattersim/forcefield/potential.py
+++ b/src/mattersim/forcefield/potential.py
@@ -1168,8 +1168,23 @@ class DeepCalculator(Calculator):
 
         self.args_dict["batch_size"] = 1
         self.args_dict["only_inference"] = 1
+        cutoff = (
+            self.potential.model.model_args["cutoff"]
+            if self.potential.model_name == "m3gnet"
+            else 5.0
+        )
+        threebody_cutoff = (
+            self.potential.model.model_args["threebody_cutoff"]
+            if self.potential.model_name == "m3gnet"
+            else 4.0
+        )
+
         dataloader = build_dataloader(
-            [atoms], model_type=self.potential.model_name, **self.args_dict
+            [atoms],
+            model_type=self.potential.model_name,
+            cutoff=cutoff,
+            threebody_cutoff=threebody_cutoff,
+            **self.args_dict,
         )
         for graph_batch in dataloader:
             # Resemble input dictionary
@@ -1311,8 +1326,23 @@ class MatterSimCalculator(Calculator):
 
         self.args_dict["batch_size"] = 1
         self.args_dict["only_inference"] = 1
+        cutoff = (
+            self.potential.model.model_args["cutoff"]
+            if self.potential.model_name == "m3gnet"
+            else 5.0
+        )
+        threebody_cutoff = (
+            self.potential.model.model_args["threebody_cutoff"]
+            if self.potential.model_name == "m3gnet"
+            else 4.0
+        )
+
         dataloader = build_dataloader(
-            [atoms], model_type=self.potential.model_name, **self.args_dict
+            [atoms],
+            model_type=self.potential.model_name,
+            cutoff=cutoff,
+            threebody_cutoff=threebody_cutoff,
+            **self.args_dict,
         )
         for graph_batch in dataloader:
             # Resemble input dictionary


### PR DESCRIPTION
This pull request includes changes to the `calculate` method in the `src/mattersim/forcefield/potential.py` file to enhance the handling of model-specific parameters. The most important changes involve the introduction of conditional cutoff values and the modification of the `build_dataloader` function call.