### PR TITLE
fix: Potential load method

### DIFF
--- a/docs/user_guide/getting_started.rst
+++ b/docs/user_guide/getting_started.rst
@@ -59,7 +59,7 @@ a list of structures using the ``Potential`` class.
     # load the model
     device = "cuda" if torch.cuda.is_available() else "cpu"
     print(f"Running MatterSim on {device}")
-    potential = Potential.load(device=device)
+    potential = Potential.from_checkpoint(device=device)
 
     # build the dataloader that is compatible with MatterSim
     dataloader = build_dataloader(structures, only_inference=True)

--- a/src/mattersim/forcefield/potential.py
+++ b/src/mattersim/forcefield/potential.py
@@ -965,27 +965,39 @@ class Potential(nn.Module):
         if model_name.lower() != "m3gnet":
             raise NotImplementedError
 
-        current_dir = os.path.dirname(__file__)
+        checkpoint_folder = os.path.expanduser("~/.local/mattersim/pretrained_models")
+        os.makedirs(checkpoint_folder, exist_ok=True)
         if (
             load_path is None
             or load_path.lower() == "mattersim-v1.0.0-1m.pth"
             or load_path.lower() == "mattersim-v1.0.0-1m"
         ):
-            load_path = os.path.join(
-                current_dir, "..", "pretrained_models/mattersim-v1.0.0-1M.pth"
-            )
+            load_path = os.path.join(checkpoint_folder, "mattersim-v1.0.0-1M.pth")
+            if not os.path.exists(load_path):
+                logger.info(
+                    "The pre-trained model is not found locally, "
+                    "attempting to download it from the server."
+                )
+                download_checkpoint(
+                    "mattersim-v1.0.0-1M.pth", save_folder=checkpoint_folder
+                )
             logger.info(f"Loading the pre-trained {os.path.basename(load_path)} model")
         elif (
             load_path.lower() == "mattersim-v1.0.0-5m.pth"
             or load_path.lower() == "mattersim-v1.0.0-5m"
         ):
-            load_path = os.path.join(
-                current_dir, "..", "pretrained_models/mattersim-v1.0.0-5M.pth"
-            )
+            load_path = os.path.join(checkpoint_folder, "mattersim-v1.0.0-5M.pth")
+            if not os.path.exists(load_path):
+                logger.info(
+                    "The pre-trained model is not found locally, "
+                    "attempting to download it from the server."
+                )
+                download_checkpoint(
+                    "mattersim-v1.0.0-5M.pth", save_folder=checkpoint_folder
+                )
             logger.info(f"Loading the pre-trained {os.path.basename(load_path)} model")
         else:
             logger.info("Loading the model from %s" % load_path)
-
         assert os.path.exists(load_path), f"Model file {load_path} not found"
 
         checkpoint = torch.load(load_path, map_location=device)


### PR DESCRIPTION
This pull request includes changes to improve the loading mechanism of the `Potential` class and update the user guide accordingly. The most important changes include modifying the `Potential` class to download checkpoints if they are not found locally and updating the user guide to reflect this change.

Improvements to loading mechanism:

* [`src/mattersim/forcefield/potential.py`](diffhunk://#diff-5d46a479c1eb71bf2a1992755fb1d897075c715f716773d0f0523c40378c826bL968-L988): Modified the `load` method in the `Potential` class to download the checkpoint from the server if it is not found locally, and updated the checkpoint folder path to use a user-specific directory.

Documentation updates:

* [`docs/user_guide/getting_started.rst`](diffhunk://#diff-c420a1b04c5b402bd0415599c46362abbd89efb728bf0d536e10db5f4250e9afL62-R62): Updated the user guide to use the `from_checkpoint` method instead of the `load` method for the `Potential` class.