### PR TITLE
Add tests and README for batch relaxation

### DIFF
--- a/docs/examples/batch_relaxation_example.rst
+++ b/docs/examples/batch_relaxation_example.rst
@@ -1,0 +1,52 @@
+Batch relaxation
+================
+
+This is a simple example of how to use MatterSim to efficiently relax a list of structures.
+
+
+Import the necessary modules
+----------------------------
+
+First we import the necessary modules.
+
+.. code-block:: python
+    :linenos:
+
+    from ase.build import bulk
+    from mattersim.applications.batch_relax import BatchRelaxer
+    from mattersim.forcefield.potential import Potential
+
+Set up the MatterSim batch relaxer
+----------------------------------
+
+.. code-block:: python
+    :linenos:
+
+    # initialize the default MatterSim Potential
+    potential = Potential.from_checkpoint()
+
+    # initialize the batch relaxer with a EXPCELLFILTER for cell relaxation and a FIRE optimizer
+    relaxer = BatchRelaxer(potential, fmax=0.01, filter="EXPCELLFILTER", optimizer="FIRE")
+
+
+Relax the structures
+--------------------
+
+.. code-block:: python
+    :linenos:
+
+    # Here, we generate a list of ASE Atoms objects we want to relax
+    atoms = [bulk("C"), bulk("Mg"), bulk("Si"), bulk("Ni")]
+
+    # Run the relaxation
+    relaxation_trajectories = relaxer.relax(atoms)
+
+
+Inspect the relaxed structures
+------------------------------
+
+    # Extract the relaxed relaxed_structures
+    relaxed_structures = [traj[-1] for traj in relaxation_trajectories]
+
+    # And the corresponding total energies
+    relaxed_energies = [structure.info['total_energy'] for structure in relaxed_structures]

--- a/docs/examples/batch_relaxation_example.rst
+++ b/docs/examples/batch_relaxation_example.rst
@@ -45,6 +45,9 @@ Relax the structures
 Inspect the relaxed structures
 ------------------------------
 
+.. code-block:: python
+    :linenos:
+    
     # Extract the relaxed relaxed_structures
     relaxed_structures = [traj[-1] for traj in relaxation_trajectories]
 

--- a/docs/examples/batch_relaxation_example.rst
+++ b/docs/examples/batch_relaxation_example.rst
@@ -1,4 +1,4 @@
-Batch relaxation
+Batch Structure Optimization
 ================
 
 This is a simple example of how to use MatterSim to efficiently relax a list of structures.

--- a/docs/examples/batch_relaxation_example.rst
+++ b/docs/examples/batch_relaxation_example.rst
@@ -38,6 +38,10 @@ Relax the structures
     # Here, we generate a list of ASE Atoms objects we want to relax
     atoms = [bulk("C"), bulk("Mg"), bulk("Si"), bulk("Ni")]
 
+    # And then perturb them a bit so that relaxation is not trivial
+    for atom in atoms:
+        atom.rattle(stdev=0.1)
+
     # Run the relaxation
     relaxation_trajectories = relaxer.relax(atoms)
 
@@ -48,8 +52,14 @@ Inspect the relaxed structures
 .. code-block:: python
     :linenos:
     
-    # Extract the relaxed relaxed_structures
-    relaxed_structures = [traj[-1] for traj in relaxation_trajectories]
-
-    # And the corresponding total energies
+    # Extract the relaxed structures and corresponding energies
+    relaxed_structures = [traj[-1] for traj in relaxation_trajectories.values()]
     relaxed_energies = [structure.info['total_energy'] for structure in relaxed_structures]
+
+    # Do the same with the initial structures and energies
+    initial_structures = [traj[0] for traj in relaxation_trajectories.values()]
+    initial_energies = [structure.info['total_energy'] for structure in initial_structures]
+
+    # verify by inspection that total energy has decreased in all instances
+    for initial_energy, relaxed_energy in zip(initial_energies, relaxed_energies):
+        print(f"Initial energy: {initial_energy} eV, relaxed energy: {relaxed_energy} eV")

--- a/docs/examples/examples.rst
+++ b/docs/examples/examples.rst
@@ -7,3 +7,4 @@ Examples
 
    relax_example
    phonon_example
+   batch_relaxation_example

--- a/src/mattersim/forcefield/potential.py
+++ b/src/mattersim/forcefield/potential.py
@@ -485,9 +485,6 @@ class Potential(nn.Module):
             - results[1] (list[np.ndarray]): a list of atomic forces
             - results[2] (list[np.ndarray]): a list of stresses
         """
-        logger.warning(
-            "The unit of stress is GPa when using the predict_properties function."
-        )
         self.model.eval()
         energies = []
         forces = []

--- a/src/mattersim/forcefield/potential.py
+++ b/src/mattersim/forcefield/potential.py
@@ -483,7 +483,7 @@ class Potential(nn.Module):
         Return: results tuple
             - results[0] (list[float]): a list of energies
             - results[1] (list[np.ndarray]): a list of atomic forces
-            - results[2] (list[np.ndarray]): a list of stresses
+            - results[2] (list[np.ndarray]): a list of stresses (in GPa)
         """
         self.model.eval()
         energies = []

--- a/tests/applications/test_batch_relax.py
+++ b/tests/applications/test_batch_relax.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+import numpy as np
+from ase import Atoms
+
+from mattersim.applications.batch_relax import BatchRelaxer
+from mattersim.forcefield.potential import Potential
+
+
+class RelaxerTestCase(unittest.TestCase):
+    def setUp(self):
+        # Create an example structure for testing
+        a = 3.567
+        positions = [
+            (0, 0, 0),
+            (a / 4, a / 4, a / 4),
+            (a / 2, a / 2, 0),
+            (a / 2, 0, a / 2),
+            (0, a / 2, a / 2),
+            (a / 4, 3 * a / 4, 3 * a / 4),
+            (3 * a / 4, a / 4, 3 * a / 4),
+            (3 * a / 4, 3 * a / 4, a / 4),
+        ]
+        cell = [(a, 0, 0), (0, a, 0), (0, 0, a)]
+        self.atoms_ideal = Atoms(
+            "C8", positions=positions, cell=cell, pbc=True  # noqa: E501
+        )
+
+        # Create an example structure with displaced atoms for testing
+        a = 3.567  # Angstroms
+        positions = [
+            (0, 0, 0),
+            (a / 4, a / 4, a / 4),
+            (a / 2, a / 2, 0),
+            (a / 2, 0, a / 2),
+            (0, a / 2, a / 2),
+            (a / 4, 3 * a / 4, 3 * a / 4.01),  # displaced
+            (3 * a / 4, a / 4.01, 3 * a / 4),  # displaced
+            (3 * a / 4, 3 * a / 4, a / 4),
+        ]
+        cell = [(a, 0, 0), (0, a, 0), (0, 0, a)]
+        self.atoms_displaced = Atoms(
+            "C8", positions=positions, cell=cell, pbc=True  # noqa: E501
+        )
+
+        # Create an example structure with expanded cell for testing
+        a = 3.567 * 1.2
+        positions = [
+            (0, 0, 0),
+            (a / 4, a / 4, a / 4),
+            (a / 2, a / 2, 0),
+            (a / 2, 0, a / 2),
+            (0, a / 2, a / 2),
+            (a / 4, 3 * a / 4, 3 * a / 4),
+            (3 * a / 4, a / 4, 3 * a / 4),
+            (3 * a / 4, 3 * a / 4, a / 4),
+        ]
+        cell = [(a, 0, 0), (0, a, 0), (0, 0, a)]
+        self.atoms_expanded = Atoms(
+            "C8", positions=positions, cell=cell, pbc=True  # noqa: E501
+        )
+        # Create a batch of structures for testing
+        self.atoms_batch = [self.atoms_ideal, self.atoms_displaced, self.atoms_expanded]
+
+        self.potential = Potential.from_checkpoint()
+
+    def test_default_batch_relaxer(self):
+        relaxer = BatchRelaxer(self.potential, fmax=0.01, filter="EXPCELLFILTER")
+        atoms_batch = self.atoms_batch.copy()
+        relaxation_trajectories = relaxer.relax(atoms_batch)
+        assert len(relaxation_trajectories) == len(atoms_batch)
+        relaxed_ideal = relaxation_trajectories[0][-1]
+        for trajectory in relaxation_trajectories.values():
+            assert len(trajectory) > 0
+            assert trajectory[-1].info["total_energy"] is not None
+            assert trajectory[-1].arrays["forces"] is not None
+            assert trajectory[-1].info["stress"] is not None
+            assert np.allclose(trajectory[-1].get_positions(), relaxed_ideal.get_positions(), atol=0.01)
+            assert np.allclose(trajectory[-1].get_cell(), relaxed_ideal.get_cell(), atol=0.01)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR:

1) Adds `batch_relaxation_example.rst` to `docs/examples`
2) Removes the WARNING message inside `predict_properties` in `src/mattersim/forcefield/potential.py`, replacing it with a comment in the file
3) Adds the batch relaxation example to `docs/examples/examples.rst`
4) Adds tests for the batch relaxation