### PR TITLE
Fix: make box smaller for no pbc structure

### DIFF
--- a/src/mattersim/datasets/utils/convertor.py
+++ b/src/mattersim/datasets/utils/convertor.py
@@ -194,7 +194,24 @@ class GraphConvertor:
                 max_x = np.max(atoms.positions[:, 0])
                 max_y = np.max(atoms.positions[:, 1])
                 max_z = np.max(atoms.positions[:, 2])      
-                x_len = (max_x - min_x) + max(self.twobody_cutoff, self.threebody_cutoff) * 2
+                x_len = (max_x - min_x) + max(
+                    self.twobody_cutoff, self.threebody_cutoff
+                ) * 5
+                y_len = (max_y - min_y) + max(
+                    self.twobody_cutoff, self.threebody_cutoff
+                ) * 5
+                z_len = (max_z - min_z) + max(
+                    self.twobody_cutoff, self.threebody_cutoff
+                ) * 5
+                max_len = max(x_len, y_len, z_len)
+                x_len = y_len = z_len = max_len
+                lattice_matrix = np.eye(3) * max_len
+                pbc_ = np.array([1, 1, 1], dtype=int)
+                warnings.warn(
+                    "No PBC detected, using a large supercell with "
+                    f"size {x_len}x{y_len}x{z_len} Angstrom**3",
+                    UserWarning,
+                )
                 y_len = (max_y - min_y) + max(self.twobody_cutoff, self.threebody_cutoff) * 2
                 z_len = (max_z - min_z) + max(self.twobody_cutoff, self.threebody_cutoff) * 2
 

--- a/src/mattersim/datasets/utils/convertor.py
+++ b/src/mattersim/datasets/utils/convertor.py
@@ -212,15 +212,7 @@ class GraphConvertor:
                     f"size {x_len}x{y_len}x{z_len} Angstrom**3",
                     UserWarning,
                 )
-                y_len = (max_y - min_y) + max(self.twobody_cutoff, self.threebody_cutoff) * 2
-                z_len = (max_z - min_z) + max(self.twobody_cutoff, self.threebody_cutoff) * 2
-
-                lattice_matrix = np.array(
-                    [[x_len, 0.0, 0.0], [0.0, y_len, 0.0], [0.0, 0.0, z_len]],
-                    dtype=float,
-                )
-                pbc_ = np.array([1, 1, 1], dtype=int)
-                warnings.warn("No PBC detected, using a large supercell", UserWarning)
+               
                 atoms.set_cell(lattice_matrix)
                 atoms.set_pbc(pbc_)
             else:

--- a/src/mattersim/datasets/utils/convertor.py
+++ b/src/mattersim/datasets/utils/convertor.py
@@ -193,10 +193,11 @@ class GraphConvertor:
                 min_z = np.min(atoms.positions[:, 2])
                 max_x = np.max(atoms.positions[:, 0])
                 max_y = np.max(atoms.positions[:, 1])
-                max_z = np.max(atoms.positions[:, 2])
-                x_len = max((max_x - min_x) * 10, 1000)
-                y_len = max((max_y - min_y) * 10, 1000)
-                z_len = max((max_z - min_z) * 10, 1000)
+                max_z = np.max(atoms.positions[:, 2])      
+                x_len = (max_x - min_x) + max(self.twobody_cutoff, self.threebody_cutoff) * 2
+                y_len = (max_y - min_y) + max(self.twobody_cutoff, self.threebody_cutoff) * 2
+                z_len = (max_z - min_z) + max(self.twobody_cutoff, self.threebody_cutoff) * 2
+
                 lattice_matrix = np.array(
                     [[x_len, 0.0, 0.0], [0.0, y_len, 0.0], [0.0, 0.0, z_len]],
                     dtype=float,


### PR DESCRIPTION
This PR aims to solve the issue mentioned in #82. When running inference on no-pbc structures, an artificial box is created and the no-pbc structure is converted to pbc structure. However, the original design gives an unnecessarily large box, which leads to data loading bottleneck due to `find_points_in_spheres` function. The GPU usage is almost zero. I provided a fix by using a smaller box. The test results are mentioned in #82 .