### PR TITLE
Unpin `torch<2.5.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "seekpath",
     "phonopy",
     "torch-ema>=0.3",
-    "torch>=2.2.0,<2.5.0",
+    "torch>=2.2.0",
     "torch_geometric>=2.5.3",
     "torch_runstats>=0.2.0",
     "torchaudio>=2.2.0",


### PR DESCRIPTION
no comment or linked issue on that pin so not clear it's really needed. but it causes `pip install mattersim==1.1.1` to fail on Python 3.13:

```
  × No solution found when resolving dependencies:
  ╰─▶ Because only the following versions of torch
      are available:
          torch<=2.2.0
          torch==2.2.1
          torch==2.2.2
          torch==2.3.0
          torch==2.3.1
          torch==2.4.0
          torch==2.4.1
          torch>2.5.0
      and torch>=2.2.0,<=2.4.1 has no wheels with
      a matching Python ABI tag (e.g., `cp313`), we
      can conclude that torch>=2.2.0,<=2.4.1 cannot
      be used.
      And because mattersim==1.1.1 depends
      on torch>=2.2.0,<2.5.0 and you require
      mattersim==1.1.1, we can conclude that your
      requirements are unsatisfiable.

      hint: You require CPython 3.13 (`cp313`), but
      we only found wheels for `torch` (v2.4.1) with
      the following Python ABI tags: `cp38`, `cp39`,
      `cp310`, `cp311`, `cp312`
```