### PR TITLE
ci: Update python-publish.yaml

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD: cp${{ matrix.python-version }}-*
 


### PR DESCRIPTION
Bump cibuildwheel version to fix building issue for python>=3.13