### PR TITLE
Fix bug with nsteps not working properly

### DIFF
--- a/src/mattersim/applications/batch_relax.py
+++ b/src/mattersim/applications/batch_relax.py
@@ -84,6 +84,7 @@ class BatchRelaxer(object):
             self.filter(atoms) if self.filter else atoms
         )
         optimizer_instance.fmax = self.fmax
+        optimizer_instance.nsteps = 0
         self.optimizer_instances.append(optimizer_instance)
         self.is_active_instance.append(True)
 
@@ -121,7 +122,8 @@ class BatchRelaxer(object):
                     ]
 
                 opt.step()
-                if opt.converged() or opt.Nsteps >= self.max_n_steps:
+                opt.nsteps += 1
+                if opt.converged() or opt.nsteps >= self.max_n_steps:
                     self.is_active_instance[idx] = False
                     self.total_converged += 1
                     if self.total_converged % 100 == 0:


### PR DESCRIPTION
Previously, batch relaxer was tracking the `Nsteps` variable for each optimizer. Unfortunately, this variable does not correspond to the total number of steps taken by the optimizer, hence the relaxation could sometimes never converge in cases where `fmax` was set to a low value and `max_n_steps` to a high number.

This fix adds a manually tracked variable `nsteps` for each optimizer class to avoid the error.