### PR TITLE
use importlib instead of pkg_resources to get pkg version

### DIFF
--- a/src/mattersim/__version__.py
+++ b/src/mattersim/__version__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import pkg_resources
+from importlib.metadata import version
 
 # Get the version from setup.py
-__version__ = pkg_resources.get_distribution("mattersim").version
+__version__ = version("mattersim")


### PR DESCRIPTION
with setuptools v81 pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30.


Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata) and their backports

since you set requires-python = ">=3.10" importlib can be used