### PR TITLE
fix: fixing import failure with setuptools>=82

### DIFF
--- a/src/mattersim/__version__.py
+++ b/src/mattersim/__version__.py
@@ -1,5 +1,6 @@
-# -*- coding: utf-8 -*-
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 
-# Get the version from setup.py
-__version__ = pkg_resources.get_distribution("mattersim").version
+try:
+    __version__ = version("mattersim")
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,36 @@
+"""
+Tests for __version__.py (GitHub issue #140):
+Mattersim failed to import with setuptools>=82 due to removed pkg_resources.
+"""
+
+import importlib
+import sys
+from unittest import mock
+
+
+def _reimport_version_module():
+    """Force a fresh import of mattersim.__version__."""
+    for mod_name in list(sys.modules):
+        if mod_name.startswith("mattersim"):
+            del sys.modules[mod_name]
+    return importlib.import_module("mattersim.__version__")
+
+
+def test_version_available():
+    """mattersim.__version__ is a non-empty string."""
+    import mattersim
+
+    assert isinstance(mattersim.__version__, str)
+    assert mattersim.__version__
+
+
+def test_import_succeeds_without_pkg_resources():
+    """Import must work when pkg_resources is absent (setuptools>=82, issue #140)."""
+    for mod_name in list(sys.modules):
+        if mod_name.startswith("mattersim"):
+            del sys.modules[mod_name]
+
+    with mock.patch.dict(sys.modules, {"pkg_resources": None}):
+        mod = importlib.import_module("mattersim.__version__")
+        assert isinstance(mod.__version__, str)
+        assert mod.__version__


### PR DESCRIPTION
Fixes issue #140

## Problem
mattersim fails to import when setuptools>=82 is installed because pkg_resources has been removed from setuptools. The error occurs in `__version__.py`.

## Changes
- `__version__.py`: Replaced `pkg_resources` with `importlib`. Falls back to "unknown" if package metadata is not found (e.g. editable/dev installs).
- `test_version.py`(new): Added two test cases:
  - Verify `mattersim.__version__` is a non-empty string
  - Verify import succeeds when `pkg_resources` is unavailable (reproduces the exact issue #140 scenario)